### PR TITLE
fix(riscv_toolchain): Change toolchain source to bao-riscv-toolchain

### DIFF
--- a/pkgs/toolchains/riscv64-unknown-elf.nix
+++ b/pkgs/toolchains/riscv64-unknown-elf.nix
@@ -6,7 +6,12 @@
 , fetchurl
 , ncurses5
 , python38
+, libmpc
+, rsync
+, mpfr
+, gmp
 , zlib
+, zstd
 }:
 
 stdenv.mkDerivation rec {
@@ -37,7 +42,7 @@ stdenv.mkDerivation rec {
     find $out -type f | while read f; do
       patchelf "$f" > /dev/null 2>&1 || continue
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
-      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 zlib]} "$f" || true
+      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 zlib libmpc mpfr gmp zstd]} "$f" || true
     done
   '';
 

--- a/pkgs/toolchains/riscv64-unknown-elf.nix
+++ b/pkgs/toolchains/riscv64-unknown-elf.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
   arch = "x86_64";
 
   src = fetchurl {
-    url = "https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-${arch}-linux-ubuntu14.tar.gz";
-    sha256 = "sha256-vYVyQrfGSxqYxWs1vIAYZKxCBdA/ODxwEKkMXQu5VJo=";
+    url = "https://github.com/bao-project/bao-riscv-toolchain/releases/download/gc891d8dc23e/riscv-unknown-elf-13.2.0-ubuntu-22.04.tar.gz";
+    sha256 = "sha256-MMKEFVwIl3wGwSZDHmvpVzEWsgpc6ePaX5kTrzyVfL0=";
   };
 
   nativeBuildInputs = [ zlib ]; #build time dependencies


### PR DESCRIPTION
## PR Description

The riscv toolchain used previously was not registring all the errors from the C11 and pedantic error flags introduced in bao-hypervisor.
This PR updates to the toolchain used to the one provided in bao-riscv-toolchain and adds the required library packages to the recipe.