### PR TITLE
feat(baremetal_rte): add support for using the baremetal runtime environment in guest recipes

### DIFF
--- a/pkgs/guest/tf/baremetal.nix
+++ b/pkgs/guest/tf/baremetal.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     # Derivation to build the baremetal-guest to run the bao test framework
     # MUT: baremetal-guest
     pname = guest_name;
-    version = "1.0.0";
+    version = "1.1.0";
 
     guest_srcs = if baremetal_srcs_path == " " || baremetal_srcs_path == null then
         fetchgit {
@@ -38,12 +38,11 @@ stdenv.mkDerivation rec {
 
     unpackPhase = ''
         mkdir -p $out
-        mkdir -p  $out/tests
+        mkdir -p $out/tests
         mkdir -p $out/tests/src
         mkdir -p $out/tests/bao-tests
 
-
-        rsync -r $guest_srcs/ $out
+        cp -r ${guest_srcs}/* $out
         rsync -r ${setup-cfg.tests_srcs}/* $out/tests/src
         rsync -r ${setup-cfg.bao-tests}/* $out/tests/bao-tests
 
@@ -61,12 +60,12 @@ stdenv.mkDerivation rec {
 
         if [ "$ARCH" == "aarch64" ]; then
             make -C $out PLATFORM=${setup-cfg.platform_name} \
-                BAO_TEST=1 SUITES=${list_suites} TESTS=${list_tests} \
+                BAO_TEST=1 SUITES="${list_suites}" TESTS="${list_tests}" \
                 TESTF_LOG_LEVEL=${log_level} \
                 ${setup-cfg.irq_flags}
         else
             make -C $out PLATFORM=${setup-cfg.platform_name} \
-                BAO_TEST=1 SUITES=${list_suites} TESTS=${list_tests} \
+                BAO_TEST=1 SUITES="${list_suites}" TESTS="${list_tests}" \
                 TESTF_LOG_LEVEL=${log_level}
         fi
     '';

--- a/pkgs/guest/tf/baremetal.nix
+++ b/pkgs/guest/tf/baremetal.nix
@@ -2,7 +2,7 @@
 # Copyright (c) Bao Project and Contributors. All rights reserved.
 
 { stdenv
-, fetchFromGitHub
+, fetchgit
 , toolchain
 , python3
 , python3Packages
@@ -23,11 +23,11 @@ stdenv.mkDerivation rec {
     version = "1.0.0";
 
     guest_srcs = if baremetal_srcs_path == " " || baremetal_srcs_path == null then
-        fetchFromGitHub {
-            owner = "bao-project";
-            repo = "bao-baremetal-guest";
-            rev = "c7973b4cbbfee1baecd6e0705261d5c4a01d3318";
-            sha256 = "sha256-uXJi9ow87P798JrztsB0BeAhqEW5Fnsx2uHfrUvPCwk=";
+        fetchgit {
+            url = "https://github.com/bao-project/bao-baremetal-test";
+            rev = "b7e83d04f49f8c98581ce8d18bb7ea8a7a6ba589";
+            sha256 = "sha256-oDKm8yxtqDvbCrZ5gnrVDEaKtFFu5WS0GYtkcJAtbbA=";
+            fetchSubmodules = true;
         }
         else
             baremetal_srcs_path;
@@ -52,17 +52,14 @@ stdenv.mkDerivation rec {
         python3 codegen.py -dir $out/tests/src -o $out/tests/bao-tests/src/testf_entry.c
         cd $out
     '';
-
-    patches = [
-        "${setup-cfg.baremetal_patch}"
-    ];
     
     buildPhase = ''
         export ARCH=${setup-cfg.arch}
         export CROSS_COMPILE=${setup-cfg.toolchain_name}-
         export TESTF_TESTS_DIR=$out/tests/src
         export TESTF_REPO_DIR=$out/tests/bao-tests
-         if [ "ARCH" == "aarch64" ]; then
+
+        if [ "$ARCH" == "aarch64" ]; then
             make -C $out PLATFORM=${setup-cfg.platform_name} \
                 BAO_TEST=1 SUITES=${list_suites} TESTS=${list_tests} \
                 TESTF_LOG_LEVEL=${log_level} \

--- a/pkgs/guest/tf/freertos.nix
+++ b/pkgs/guest/tf/freertos.nix
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Bao Project and Contributors. All rights reserved.
+
+{ stdenv
+, fetchgit
+, toolchain
+, python3
+, python3Packages
+, rsync
+, setup-cfg
+, guest_name ? "freertos"
+, freertos_srcs_path ? " "
+, tests_path ? " "
+, list_tests ? " "
+, list_suites ? " "
+, log_level ? "2"
+}:
+
+stdenv.mkDerivation rec {
+    # Derivation to build the freertos-guest to run the bao test framework
+    # MUT: freertos-guest
+    pname = guest_name;
+    version = "1.0";
+
+        guest_srcs = if freertos_srcs_path == " " || freertos_srcs_path == null then
+        fetchgit {
+            url = "https://github.com/bao-project/bao-freertos-test";
+            rev = "b10f6d69551f3c74eccd0439dd6b58e65794a0e4";
+            sha256 = "sha256-iRI0z1dbmSO2JYKqBUrhJSnZzr6Np090zeDT53VB2O8=";
+            fetchSubmodules = true;
+        }
+        else
+            freertos_srcs_path;
+
+
+    nativeBuildInputs = [ toolchain]; #build time dependencies
+    buildInputs = [python3 python3Packages.numpy rsync];
+
+    unpackPhase = ''
+        mkdir -p $out
+        mkdir -p  $out/tests
+        mkdir -p $out/tests/src
+        mkdir -p $out/tests/bao-tests
+
+        rsync -a ${guest_srcs}/* $out    
+        rsync -r ${setup-cfg.tests_srcs}/* $out/tests/src
+        rsync -r ${setup-cfg.bao-tests}/* $out/tests/bao-tests
+
+        chmod -R +rwx $out/
+        cd $out/tests/bao-tests/framework
+        python3 codegen.py -dir $out/tests/src -o $out/tests/bao-tests/src/testf_entry.c
+        cd $out
+    '';
+
+    buildPhase = ''
+        export ARCH=${setup-cfg.arch}
+        export CROSS_COMPILE=${setup-cfg.toolchain_name}-
+        export TESTF_TESTS_DIR=$out/tests/src
+        export TESTF_REPO_DIR=$out/tests/bao-tests
+        export FREERTOS_PARAMS="STD_ADDR_SPACE=y"
+        if [ "$ARCH" = "aarch64" ]; then
+            make -C $out PLATFORM=${setup-cfg.platform_name} \
+                BAO_TEST=1 SUITES=${list_suites} TESTS=${list_tests} \
+                TESTF_LOG_LEVEL=${log_level} \
+                ${setup-cfg.irq_flags} $FREERTOS_PARAMS
+        else
+            make -C $out PLATFORM=${setup-cfg.platform_name} \
+                BAO_TEST=1 SUITES="${list_suites}" TESTS="${list_tests}" \
+                TESTF_LOG_LEVEL=${log_level} $FREERTOS_PARAMS
+        fi
+    '';
+
+    installPhase = ''
+        mkdir -p $out/bin
+        cp $out/build/${setup-cfg.platform_name}/freertos.bin $out/bin/${guest_name}.bin
+    '';
+
+}

--- a/pkgs/guest/tf/freertos.nix
+++ b/pkgs/guest/tf/freertos.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
         export FREERTOS_PARAMS="STD_ADDR_SPACE=y"
         if [ "$ARCH" = "aarch64" ]; then
             make -C $out PLATFORM=${setup-cfg.platform_name} \
-                BAO_TEST=1 SUITES=${list_suites} TESTS=${list_tests} \
+                BAO_TEST=1 SUITES="${list_suites}" TESTS="${list_tests}" \
                 TESTF_LOG_LEVEL=${log_level} \
                 ${setup-cfg.irq_flags} $FREERTOS_PARAMS
         else


### PR DESCRIPTION
## PR Description

This PR updates the baremetal guest and adds support for the FreeRTOS guest to use the baremetal runtime environment. This change eliminates the need for the previously required patch to deploy tests on these guests.
